### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   test:
    runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/acardosolima/sports_betting/security/code-scanning/1](https://github.com/acardosolima/sports_betting/security/code-scanning/1)

In general, the problem is fixed by explicitly specifying a `permissions` block for the workflow or for each job, restricting the `GITHUB_TOKEN` to the least privileges needed. For this workflow, the steps only read code, install dependencies, run tests, and upload coverage to Codecov, so they do not need to write to the repository. A minimal and appropriate configuration is `permissions: contents: read` at the top level of the workflow so it applies to all jobs.

The best fix without changing existing functionality is to add a root-level `permissions` block (between `on:` and `jobs:`) in `.github/workflows/test.yml`. This will ensure the `GITHUB_TOKEN` has only read access to repository contents. No additional methods, imports, or definitions are required; this is purely a YAML configuration change in the workflow file. No job-specific overrides are necessary since there is only a single job and it does not require write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
